### PR TITLE
feat: add google cloud storate gcs to deployment flow

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,9 +8,10 @@ set -e
 if [ -f "terraform/terraform.tfvars" ]; then
     # Extract the value, remove quotes and comments
     GCP_PROJECT_ID_FROM_TFVARS=$(grep -E '^[[:space:]]*gcp_project_id[[:space:]]*=' terraform/terraform.tfvars | awk -F'=' '{print $2}' | awk '{$1=$1};1' | tr -d '"' | awk -F'#' '{print $1}' | awk '{$1=$1};1')
+    TERRAFORM_STATE_BUCKET_FROM_TFVARS=$(grep -E '^[[:space:]]*terraform_state_bucket_name[[:space:]]*=' terraform/terraform.tfvars | awk -F'=' '{print $2}' | awk '{$1=$1};1' | tr -d '"' | awk -F'#' '{print $1}' | awk '{$1=$1};1')
 fi
 
-# Use value from TFVARS, or environment variable, or prompt user
+# Use value from TFVARS, or environment variable, or prompt user for Project ID
 if [ -n "$GCP_PROJECT_ID_FROM_TFVARS" ]; then
     export GCP_PROJECT_ID="$GCP_PROJECT_ID_FROM_TFVARS"
 elif [ -n "$TF_VAR_gcp_project_id" ]; then
@@ -23,6 +24,21 @@ else
         exit 1
     fi
     export GCP_PROJECT_ID="$GCP_PROJECT_ID_INPUT"
+fi
+
+# Use value from TFVARS, or environment variable TF_VAR_terraform_state_bucket_name, or prompt for Terraform State Bucket Name
+if [ -n "$TERRAFORM_STATE_BUCKET_FROM_TFVARS" ]; then
+    export TERRAFORM_STATE_BUCKET_NAME="$TERRAFORM_STATE_BUCKET_FROM_TFVARS"
+elif [ -n "$TF_VAR_terraform_state_bucket_name" ]; then
+    export TERRAFORM_STATE_BUCKET_NAME="$TF_VAR_terraform_state_bucket_name"
+else
+    echo "Error: terraform_state_bucket_name not found in terraform/terraform.tfvars or TF_VAR_terraform_state_bucket_name env var."
+    read -p "Please enter the GCS Bucket Name for Terraform state (must be globally unique): " TERRAFORM_STATE_BUCKET_INPUT
+    if [ -z "$TERRAFORM_STATE_BUCKET_INPUT" ]; then
+        echo "Terraform state bucket name cannot be empty. Aborting."
+        exit 1
+    fi
+    export TERRAFORM_STATE_BUCKET_NAME="$TERRAFORM_STATE_BUCKET_INPUT"
 fi
 
 export GCP_REGION="${TF_VAR_gcp_region:-us-west2}"
@@ -47,7 +63,24 @@ echo "Project ID:   ${GCP_PROJECT_ID}"
 echo "Region:       ${GCP_REGION}"
 echo "Image Tag:    ${IMAGE_TAG}"
 echo "Repo Name:    ${AR_REPO_NAME}"
+echo "Terraform State Bucket: ${TERRAFORM_STATE_BUCKET_NAME}"
 echo "---------------------"
+
+# --- Create Terraform State Bucket (if it doesn't exist) --- #
+echo "\n---> Checking/Creating GCS bucket for Terraform state: gs://${TERRAFORM_STATE_BUCKET_NAME}..."
+if ! gcloud storage buckets describe "gs://${TERRAFORM_STATE_BUCKET_NAME}" --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+    echo "Bucket gs://${TERRAFORM_STATE_BUCKET_NAME} not found. Creating..."
+    if gcloud storage buckets create "gs://${TERRAFORM_STATE_BUCKET_NAME}" --project "${GCP_PROJECT_ID}" --location "${GCP_REGION}" --uniform-bucket-level-access; then
+        echo "Bucket gs://${TERRAFORM_STATE_BUCKET_NAME} created successfully."
+        echo "Enabling versioning for gs://${TERRAFORM_STATE_BUCKET_NAME}..."
+        gcloud storage buckets update "gs://${TERRAFORM_STATE_BUCKET_NAME}" --versioning
+    else
+        echo "Failed to create bucket gs://${TERRAFORM_STATE_BUCKET_NAME}. Please check permissions or if the name is already taken globally. Aborting."
+        exit 1
+    fi
+else
+    echo "Bucket gs://${TERRAFORM_STATE_BUCKET_NAME} already exists."
+fi
 
 # --- Step 1: Ensure Artifact Registry Exists via Terraform --- #
 echo "\n---> Applying Terraform configuration for Artifact Registry..."
@@ -55,8 +88,9 @@ cd terraform
 tf_repo_resource="google_artifact_registry_repository.n8n_repo"
 tf_service_resource="google_project_service.artifactregistry"
 
+echo "Current directory before terraform init: $(pwd)"
 echo "Initializing Terraform..."
-terraform init -reconfigure
+terraform init -reconfigure -backend-config="bucket=${TERRAFORM_STATE_BUCKET_NAME}" -backend-config="prefix=n8n-instance/state"
 
 echo "Applying target: ${tf_service_resource} and ${tf_repo_resource}..."
 # Apply only the API enablement and the repo creation first
@@ -80,6 +114,8 @@ docker push "${IMAGE_TAG}"
 # --- Step 5: Apply Remaining Terraform Configuration --- #
 echo "\n---> Applying full Terraform configuration..."
 cd terraform
+echo "Current directory before terraform init: $(pwd)"
+terraform init -reconfigure -backend-config="bucket=${TERRAFORM_STATE_BUCKET_NAME}" -backend-config="prefix=n8n-instance/state"
 terraform apply -auto-approve
 
 echo "\n---> Deployment process completed."

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,12 @@ terraform {
       version = ">= 4.0"
     }
   }
+  backend "gcs" {
+    # The bucket name will be configured dynamically during 'terraform init'
+    # using -backend-config="bucket=<your_bucket_name>"
+    # The prefix helps organize state files if the bucket is used for multiple projects/environments.
+    prefix = "n8n-instance/state"
+  }
 }
 
 provider "google" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -2,17 +2,18 @@
 # Rename this to terraform.tfvars and fill in the sensitive values.
 
 # --- Required --- #
-db_password        = "YOUR_SECURE_DB_PASSWORD"
-n8n_encryption_key = "YOUR_VERY_LONG_RANDOM_ENCRYPTION_KEY"
+db_password                   = "YOUR_SECURE_DB_PASSWORD"
+n8n_encryption_key            = "YOUR_VERY_LONG_RANDOM_ENCRYPTION_KEY"
+terraform_state_bucket_name = n8n-instance-production-terraform-state" # Replace with a globally unique name, e.g., n8n-instance-production-terraform-state
 
 # --- Optional (Defaults are likely suitable based on your setup) --- #
-# gcp_project_id = "allie-n8n"
+# gcp_project_id = "n8n-instance-ygg"
 # gcp_region     = "us-west2"
 # db_name        = "n8n"
 # db_user        = "n8n-user"
 # db_tier        = "db-f1-micro"
 # db_storage_size = 10
-# artifact_repo_name = "allie-n8n"
+# artifact_repo_name = "n8n-instance-ygg"
 # cloud_run_service_name = "n8n"
 # service_account_name = "n8n-service-account"
 # cloud_run_cpu = "2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -93,3 +93,9 @@ variable "generic_timezone" {
   type        = string
   default     = "UTC" # As per the working config
 }
+
+variable "terraform_state_bucket_name" {
+  type        = string
+  description = "The GCS bucket name where Terraform state will be stored. This is read by the deploy script and passed to 'terraform init -backend-config'."
+  # No default is provided here as the deploy.sh script handles sourcing it.
+}


### PR DESCRIPTION
# Summary

The changes for the PR is that we've updated the deployment script to build, configure, and update a Google Cloud Storage object with the terraform state upon each successful run of the deploy.sh script.

This is not perfect and ideal state is that we have proper CI CD which builds the TF state, handles some of the variables, and has CI checks but for a quick initial V1 of this - this is good enough for now.

Once we prove out N8N more we can upgrade the CI CD for this.

<img width="789" alt="Screenshot 2025-05-08 at 4 28 52 PM" src="https://github.com/user-attachments/assets/cc63678d-fdcf-425d-bcae-b5dbda001447" />

<img width="798" alt="Screenshot 2025-05-08 at 4 40 59 PM" src="https://github.com/user-attachments/assets/d8fe6aed-51b8-4af8-a5a3-af1fe75fa7af" />

<img width="1366" alt="Screenshot 2025-05-08 at 4 36 39 PM" src="https://github.com/user-attachments/assets/ec8a3491-2c5e-4a22-8cbc-7138a84307d4" />
